### PR TITLE
fix: add missing <cstdint> include for GCC 13+ compatibility

### DIFF
--- a/src/gdshader/semantics/types.hpp
+++ b/src/gdshader/semantics/types.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <memory>
 #include <algorithm>
+#include <cstdint>
 
 namespace gdshader_lsp {
 


### PR DESCRIPTION
GCC 13's libstdc++ no longer transitively includes <cstdint> through headers like <algorithm>, breaking the build with 'uint32_t does not name a type'. I just added the include explicitly.

Tested on GCC 16.1.1, for the Distro I am on (Arch linux).